### PR TITLE
Fixes exception when retrieving location from profile.

### DIFF
--- a/lib/ueberauth/strategy/steam.ex
+++ b/lib/ueberauth/strategy/steam.ex
@@ -87,7 +87,7 @@ defmodule Ueberauth.Strategy.Steam do
     %Info{
       image: user.avatar,
       name: user.realname,
-      location: user.loccountrycode,
+      location: Map.get(user, :loccountrycode),
       urls: %{
         Steam: user.profileurl,
       }


### PR DESCRIPTION
refer #1 

since `Map.get` returns nil if there's no result that'd be the default value from the struct.