### PR TITLE
a bunch of fixes

### DIFF
--- a/lib/ueberauth/strategy/steam.ex
+++ b/lib/ueberauth/strategy/steam.ex
@@ -24,9 +24,8 @@ defmodule Ueberauth.Strategy.Steam do
   @doc ~S"""
   Handles the callback from Steam.
   """
-  def handle_callback!(conn) do
+  def handle_callback!(%{params: %{"openid.mode" => "id_res"}} = conn) do
     with \
-      %{"openid.mode" => "id_res"} <- conn.params,
       {:ok, %{"openid.claimed_id" => claimed_id}} <- check_authentication(conn.params),
       {:ok, steam_user_id} <- get_steam_user_id(claimed_id),
       {:ok, steam_user} <- get_steam_user(steam_user_id)
@@ -38,8 +37,11 @@ defmodule Ueberauth.Strategy.Steam do
       {:error, :invalid_user} ->
         set_errors!(conn, [error("invalid_user", "Invalid Steam user")])
       _ ->
-        set_errors!(conn, [error("invalid_response", "Invalid response received")])
+        set_errors!(conn, [error("invalid_response", "Invalid response")])
     end
+  end
+  def handle_callback!(conn) do
+    set_errors!(conn, [error("invalid_request", "Invalid request")])
   end
   
   @doc false

--- a/lib/ueberauth/strategy/steam.ex
+++ b/lib/ueberauth/strategy/steam.ex
@@ -4,92 +4,72 @@ defmodule Ueberauth.Strategy.Steam do
   """
 
   use Ueberauth.Strategy
-
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Extra
+  
+  defdelegate checkid_setup_url(callback_url), to: __MODULE__.OpenID
+  defdelegate check_authentication(params), to: __MODULE__.OpenID
+  defdelegate get_steam_user_id(claimed_id), to: __MODULE__.OpenID
+  defdelegate get_steam_user(steam_user_id), to: __MODULE__.API
 
   @doc ~S"""
   Handles initial request for Steam authentication.
 
   Redirects the given `conn` to the Steam login page.
   """
-  @spec handle_request!(Plug.Conn.t) :: Plug.Conn.t
   def handle_request!(conn) do
-    query =
-      %{
-        "openid.mode" => "checkid_setup",
-        "openid.realm" => callback_url(conn),
-        "openid.return_to" => callback_url(conn),
-        "openid.ns" => "http://specs.openid.net/auth/2.0",
-        "openid.claimed_id" => "http://specs.openid.net/auth/2.0/identifier_select",
-        "openid.identity" => "http://specs.openid.net/auth/2.0/identifier_select",
-      }
-      |> URI.encode_query
-
-    redirect!(conn, "https://steamcommunity.com/openid/login?" <> query)
+    redirect!(conn, checkid_setup_url(callback_url(conn)))
   end
 
   @doc ~S"""
   Handles the callback from Steam.
   """
-  @spec handle_callback!(Plug.Conn.t) :: Plug.Conn.t
-  def handle_callback!(conn = %Plug.Conn{params: %{"openid.mode" => "id_res"}}) do
-    params = conn.params
-
-    [valid, user] =
-      [ # Validate and retrieve the steam user at the same time.
-        fn -> validate_user(params) end,
-        fn -> retrieve_user(params) end,
-      ]
-      |> Enum.map(&Task.async/1)
-      |> Enum.map(&Task.await/1)
-
-    case valid && !is_nil(user) do
-      true ->
-        conn
-        |> put_private(:steam_user, user)
-      false ->
-        set_errors!(conn, [error("invalid_user", "Invalid steam user")])
+  def handle_callback!(conn) do
+    with \
+      %{"openid.mode" => "id_res"} <- conn.params,
+      {:ok, %{"openid.claimed_id" => claimed_id}} <- check_authentication(conn.params),
+      {:ok, steam_user_id} <- get_steam_user_id(claimed_id),
+      {:ok, steam_user} <- get_steam_user(steam_user_id)
+    do
+      conn |> put_private(:steam_user, steam_user)
+    else
+      {:error, :invalid_request} ->
+        set_errors!(conn, [error("invalid_openid", "Invalid OpenID authentication request")])
+      {:error, :invalid_user} ->
+        set_errors!(conn, [error("invalid_user", "Invalid Steam user")])
+      _ ->
+        set_errors!(conn, [error("invalid_response", "Invalid response received")])
     end
   end
-
+  
   @doc false
-  def handle_callback!(conn) do
-    set_errors!(conn, [error("invalid_openid", "Invalid openid response received")])
-  end
-
-  @doc false
-  @spec handle_cleanup!(Plug.Conn.t) :: Plug.Conn.t
   def handle_cleanup!(conn) do
-    conn
-    |> put_private(:steam_user, nil)
+    conn |> put_private(:steam_user, nil)
   end
-
+  
   @doc ~S"""
   Fetches the uid field from the response.
 
-  Takes the `steamid` from the `steamuser` saved in the `conn`.
+  Takes the information from `steam_user` saved in `conn`.
   """
-  @spec uid(Plug.Conn.t) :: pos_integer
   def uid(conn) do
-    conn.private.steam_user.steamid |> String.to_integer
+    String.to_integer(conn.private.steam_user["steamid"])
   end
-
+  
   @doc ~S"""
   Fetches the fields to populate the info section of the `Ueberauth.Auth` struct.
 
-  Takes the information from the `steamuser` saved in the `conn`.
+  Takes the information from `steam_user` saved in `conn`.
   """
-  @spec info(Plug.Conn.t) :: Info.t
   def info(conn) do
-    user = conn.private.steam_user
-
+    steam_user = conn.private.steam_user
     %Info{
-      image: user.avatar,
-      name: user.realname,
-      location: user.loccountrycode,
+      name: steam_user["realname"],
+      nickname: steam_user["personaname"],
+      image: steam_user["avatar"],
+      location: steam_user["loccountrycode"],
       urls: %{
-        Steam: user.profileurl,
+        steam_profile: steam_user["profileurl"]
       }
     }
   end
@@ -99,7 +79,6 @@ defmodule Ueberauth.Strategy.Steam do
 
   Returns the `steamuser` saved in the `conn` as `raw_info`.
   """
-  @spec extra(Plug.Conn.t) :: Extra.t
   def extra(conn) do
     %Extra{
       raw_info: %{
@@ -107,51 +86,4 @@ defmodule Ueberauth.Strategy.Steam do
       }
     }
   end
-
-  @spec retrieve_user(map) :: map | nil
-  defp retrieve_user(%{"openid.claimed_id" => "http://steamcommunity.com/openid/id/" <> id}) do
-    key =
-      :ueberauth
-      |> Application.fetch_env!(Ueberauth.Strategy.Steam)
-      |> Keyword.get(:api_key)
-    url = "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=" <> key <> "&steamids=" <> id
-
-    with {:ok, %HTTPoison.Response{body: body}} <- HTTPoison.get(url),
-         {:ok, user} <- Poison.decode(body, keys: :atoms)
-    do
-      List.first(user.response.players)
-    else
-      _ -> nil
-    end
-  end
-
-  @spec validate_user(map) :: boolean
-  defp validate_user(params) do
-    query =
-      params
-      |> Enum.filter(fn {key, _value} -> String.starts_with?(key, "openid.") end)
-      |> Enum.into(%{})
-      |> Map.put("openid.mode", "check_authentication")
-      |> URI.encode_query
-
-    case HTTPoison.get("https://steamcommunity.com/openid/login?" <> query) do
-      {:ok, %HTTPoison.Response{body: body, status_code: 200}} ->
-        String.contains?(body, "is_valid:true\n")
-      _ ->
-        false
-    end
-  end
-
-  # Block undocumented function
-  @doc false
-  @spec default_options :: []
-  def default_options
-
-  @doc false
-  @spec credentials(Plug.Conn.t) :: Ueberauth.Auth.Credentials.t
-  def credentials(_conn), do: %Ueberauth.Auth.Credentials{}
-
-  @doc false
-  @spec auth(Plug.Conn.t) :: Ueberauth.Auth.t
-  def auth(conn)
 end

--- a/lib/ueberauth/strategy/steam/api.ex
+++ b/lib/ueberauth/strategy/steam/api.ex
@@ -1,0 +1,21 @@
+defmodule Ueberauth.Strategy.Steam.API do
+  @url_steam_summaries "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002"
+
+  defp get_steam_api_key do
+    {:ok, env} = Application.fetch_env(:ueberauth, Ueberauth.Strategy.Steam)
+    {:ok, api_key} = Keyword.fetch(env, :api_key)
+    api_key
+  end
+  
+  def get_steam_user(steam_user_id) do
+    with \
+      params <- %{key: get_steam_api_key(), steamids: steam_user_id},
+      {:ok, %{body: body}} <- HTTPoison.get(@url_steam_summaries, [], params: params),
+      {:ok, %{"response" => %{"players" => [player|_]}}} <- Poison.decode(body)
+    do
+      {:ok, player}
+    else _ ->
+      {:error, :invalid_user}
+    end
+  end
+end

--- a/lib/ueberauth/strategy/steam/openid.ex
+++ b/lib/ueberauth/strategy/steam/openid.ex
@@ -1,0 +1,34 @@
+defmodule Ueberauth.Strategy.Steam.OpenID do
+  @url_namespace "http://specs.openid.net/auth/2.0"
+  @url_login "https://steamcommunity.com/openid/login"
+  
+  def checkid_setup_url(callback_url) do
+    query = checkid_setup_query(callback_url, callback_url)
+    @url_login <> "?" <> URI.encode_query(query)
+  end
+  
+  defp checkid_setup_query(realm, return_to) do
+    %{
+      "openid.mode" => "checkid_setup",
+      "openid.realm" => return_to,
+      "openid.return_to" => return_to,
+      "openid.ns" => @url_namespace,
+      "openid.claimed_id" => @url_namespace <> "/identifier_select",
+      "openid.identity" => @url_namespace <> "/identifier_select",
+    }
+  end
+
+  def check_authentication(params) do
+    check_params = Map.put(params, "openid.mode", "check_authentication")
+    case HTTPoison.get(@url_login, [], params: check_params) do
+      {:ok, %{status_code: 200, body: "ns:" <> @url_namespace <> "\nis_valid:true\n"}} ->
+        {:ok, params}
+      _ ->
+        {:error, :invalid_request}
+    end
+  end
+
+  def get_steam_user_id("http://steamcommunity.com/openid/id/" <> id), do: {:ok, id}
+  def get_steam_user_id("https://steamcommunity.com/openid/id/" <> id), do: {:ok, id}
+  def get_steam_user_id(_), do: {:error, :badarg}
+end

--- a/lib/ueberauth/strategy/steam/openid.ex
+++ b/lib/ueberauth/strategy/steam/openid.ex
@@ -10,7 +10,7 @@ defmodule Ueberauth.Strategy.Steam.OpenID do
   defp checkid_setup_query(realm, return_to) do
     %{
       "openid.mode" => "checkid_setup",
-      "openid.realm" => return_to,
+      "openid.realm" => realm,
       "openid.return_to" => return_to,
       "openid.ns" => @url_namespace,
       "openid.claimed_id" => @url_namespace <> "/identifier_select",

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule UeberauthSteam.Mixfile do
 
       # Testing
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
+      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
       dialyzer: [ignore_warnings: "dialyzer.ignore-warnings"],
 
       # Docs

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule UeberauthSteam.Mixfile do
       {:ueberauth, "~> 0.4"},
 
       # Testing
-      {:meck, "~> 0.8.4", only: :test},
+      {:meck, "~> 0.8.12", only: :test},
 
       # Code Maintenance
       {:credo, "~> 0.7", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "certifi": {:hex, :certifi, "1.1.0", "c9b71a547016c2528a590ccfc28de786c7edb74aafa17446b84f54e04efc00ee", [:rebar3], []},
   "credo": {:hex, :credo, "0.7.4", "0c33bcce4d574ce6df163cbc7d1ecb22de65713184355bd3be81cc4ab0ecaafa", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
@@ -11,7 +12,7 @@
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], []},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
+  "meck": {:hex, :meck, "0.8.12", "1f7b1a9f5d12c511848fec26bbefd09a21e1432eadb8982d9a8aceb9891a3cf2", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
@@ -19,4 +20,5 @@
   "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "ueberauth": {:hex, :ueberauth, "0.4.0", "bc72d5e5a7bdcbfcf28a756e34630816edabc926303bdce7e171f7ac7ffa4f91", [:mix], [{:plug, "~> 1.2", [hex: :plug, optional: false]}]}}
+  "ueberauth": {:hex, :ueberauth, "0.4.0", "bc72d5e5a7bdcbfcf28a756e34630816edabc926303bdce7e171f7ac7ffa4f91", [:mix], [{:plug, "~> 1.2", [hex: :plug, optional: false]}]},
+}

--- a/test/ueberauth/strategy/steam_test.exs
+++ b/test/ueberauth/strategy/steam_test.exs
@@ -4,142 +4,106 @@ defmodule Ueberauth.Strategy.SteamTest do
 
   alias Ueberauth.Strategy.Steam
 
-  @sample_user %{avatar: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe.jpg",
-       avatarfull: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe_full.jpg",
-       avatarmedium: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe_medium.jpg",
-       communityvisibilitystate: 1, lastlogoff: 234234234, loccityid: 36148,
-       loccountrycode: "NL", locstatecode: "03", personaname: "Sample",
-       personastate: 0, personastateflags: 0,
-       primaryclanid: "435345345", profilestate: 1,
-       profileurl: "http://steamcommunity.com/id/sample/",
-       realname: "Sample Sample", steamid: "765309403423",
-       timecreated: 452342342}
-  @sample_response %{response: %{players: [@sample_user]}}
+  @sample_user %{
+    "avatar" => "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe.jpg",
+    "avatarfull" => "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe_full.jpg",
+    "avatarmedium" => "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe_medium.jpg",
+    "communityvisibilitystate" => 1,
+    "lastlogoff" => 234234234,
+    "loccityid" => 36148,
+    "loccountrycode" => "NL",
+    "locstatecode" => "03",
+    "personaname" => "Sample",
+    "personastate" => 0,
+    "personastateflags" => 0,
+    "primaryclanid" => "435345345",
+    "profilestate" => 1,
+    "profileurl" => "http://steamcommunity.com/id/sample/",
+    "realname" => "Sample Sample",
+    "steamid" => "765309403423",
+    "timecreated" => 452342342
+  }
+  @sample_response %{
+    "response" => %{
+      "players" => [@sample_user]
+    }
+  }
 
   describe "handle_request!" do
     test "redirects" do
       conn = Steam.handle_request! conn(:get, "http://example.com/path")
-
       assert conn.state == :sent
       assert conn.status == 302
     end
 
     test "redirects to the right url" do
       conn = Steam.handle_request! conn(:get, "http://example.com/path")
-
       {"location", location} = List.keyfind(conn.resp_headers, "location", 0)
-
-      assert location == "https://steamcommunity.com/openid/login?openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.mode=checkid_setup&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.realm=http%3A%2F%2Fexample.com&openid.return_to=http%3A%2F%2Fexample.com"
+      location_url = URI.parse(location)
+      location_query = URI.decode_query(location_url.query)
+      assert %{host: "steamcommunity.com", path: "/openid/login", scheme: "https"} = location_url
+      assert %{
+        "openid.realm" => "http://example.com",
+        "openid.return_to" => "http://example.com"
+      } = location_query
     end
   end
 
   describe "handle_callback!" do
     setup do
-      :meck.new Application, [:passthrough]
-      :meck.expect Application, :fetch_env!, fn _, _ -> [api_key: "API_KEY"] end
-
-      on_exit(fn -> :meck.unload end)
-
-      :ok
+      on_exit(&:meck.unload/0)
+      :meck.new(Application, [:passthrough])
+      :meck.expect(Application, :fetch_env, fn :ueberauth, Ueberauth.Strategy.Steam ->
+        {:ok, [api_key: "API_KEY"]}
+      end)
+      [
+        mock: fn auth_resp, user_resp ->
+          :meck.new HTTPoison, [:passthrough]
+          :meck.expect(HTTPoison, :get, fn
+            "https://steamcommunity.com/openid/login", _, _ ->
+              {:ok, %HTTPoison.Response{body: auth_resp, status_code: 200}}
+            "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002", _, _ ->
+              {:ok, %HTTPoison.Response{body: user_resp, status_code: 200}}
+          end)
+        end,
+        payload: %{
+          "openid.mode" => "id_res",
+          "openid.claimed_id" => "http://steamcommunity.com/openid/id/12345"
+        }
+      ]
     end
 
     defp callback(params \\ %{}) do
       conn = %{conn(:get, "http://example.com/path/callback") | params: params}
-
       Steam.handle_callback! conn
     end
 
     test "error for invalid callback parameters" do
       conn = callback()
-
-      assert conn.assigns == %{
-          ueberauth_failure: %Ueberauth.Failure{errors: [
-            %Ueberauth.Failure.Error{message: "Invalid openid response received", message_key: "invalid_openid"}
-          ], provider: nil, strategy: nil}
-        }
+      assert %{ueberauth_failure: %{errors: [%{message_key: "invalid_request"}]}} = conn.assigns
     end
 
-    test "error for missing user valid information" do
-      :meck.new HTTPoison, [:passthrough]
-      :meck.expect HTTPoison, :get, fn
-        "https://steamcommunity.com/openid/login?openid.claimed_id=http%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F12345&openid.mode=check_authentication" ->
-          {:ok, %HTTPoison.Response{body: "", status_code: 200}}
-        "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=API_KEY&steamids=12345" ->
-          {:ok, %HTTPoison.Response{body: Poison.encode!(@sample_response), status_code: 200}}
-      end
-
-      conn =
-        callback(%{
-          "openid.mode" => "id_res",
-          "openid.claimed_id" => "http://steamcommunity.com/openid/id/12345"
-        })
-
-      assert conn.assigns == %{
-          ueberauth_failure: %Ueberauth.Failure{errors: [
-            %Ueberauth.Failure.Error{message: "Invalid steam user", message_key: "invalid_user"}
-          ], provider: nil, strategy: nil}
-        }
+    test "error for missing user valid information", context do
+      context.mock.("", Poison.encode!(@sample_response))
+      conn = callback(context.payload)
+      assert %{ueberauth_failure: %{errors: [%{message_key: "invalid_openid"}]}} = conn.assigns
     end
 
-    test "error for invalid user callback" do
-      :meck.new HTTPoison, [:passthrough]
-      :meck.expect HTTPoison, :get, fn
-        "https://steamcommunity.com/openid/login?openid.claimed_id=http%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F12345&openid.mode=check_authentication" ->
-          {:ok, %HTTPoison.Response{body: "is_valid:false\n", status_code: 200}}
-        "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=API_KEY&steamids=12345" ->
-          {:ok, %HTTPoison.Response{body: Poison.encode!(@sample_response), status_code: 200}}
-      end
-
-      conn =
-        callback(%{
-          "openid.mode" => "id_res",
-          "openid.claimed_id" => "http://steamcommunity.com/openid/id/12345"
-        })
-
-      assert conn.assigns == %{
-          ueberauth_failure: %Ueberauth.Failure{errors: [
-            %Ueberauth.Failure.Error{message: "Invalid steam user", message_key: "invalid_user"}
-          ], provider: nil, strategy: nil}
-        }
+    test "error for invalid user callback", context do
+      context.mock.("ns:http://specs.openid.net/auth/2.0\nis_valid:false\n", Poison.encode!(@sample_response))
+      conn = callback(context.payload)
+      assert %{ueberauth_failure: %{errors: [%{message_key: "invalid_openid"}]}} = conn.assigns
     end
 
-    test "error for invalid user data" do
-      :meck.new HTTPoison, [:passthrough]
-      :meck.expect HTTPoison, :get, fn
-        "https://steamcommunity.com/openid/login?openid.claimed_id=http%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F12345&openid.mode=check_authentication" ->
-          {:ok, %HTTPoison.Response{body: "is_valid:true\n", status_code: 200}}
-        "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=API_KEY&steamids=12345" ->
-          {:ok, %HTTPoison.Response{body: "{{{{{{{", status_code: 200}}
-      end
-
-      conn =
-        callback(%{
-          "openid.mode" => "id_res",
-          "openid.claimed_id" => "http://steamcommunity.com/openid/id/12345"
-        })
-
-      assert conn.assigns == %{
-          ueberauth_failure: %Ueberauth.Failure{errors: [
-            %Ueberauth.Failure.Error{message: "Invalid steam user", message_key: "invalid_user"}
-          ], provider: nil, strategy: nil}
-        }
+    test "error for invalid user data", context do
+      context.mock.("ns:http://specs.openid.net/auth/2.0\nis_valid:true\n", "{{{{{{{")
+      conn = callback(context.payload)
+      assert %{ueberauth_failure: %{errors: [%{message_key: "invalid_user"}]}} = conn.assigns
     end
 
-    test "success for valid user and valid user data" do
-      :meck.new HTTPoison, [:passthrough]
-      :meck.expect HTTPoison, :get, fn
-        "https://steamcommunity.com/openid/login?openid.claimed_id=http%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F12345&openid.mode=check_authentication" ->
-          {:ok, %HTTPoison.Response{body: "is_valid:true\n", status_code: 200}}
-        "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=API_KEY&steamids=12345" ->
-          {:ok, %HTTPoison.Response{body: Poison.encode!(@sample_response), status_code: 200}}
-      end
-
-      conn =
-        callback(%{
-          "openid.mode" => "id_res",
-          "openid.claimed_id" => "http://steamcommunity.com/openid/id/12345"
-        })
-
+    test "success for valid user and valid user data", context do
+      context.mock.("ns:http://specs.openid.net/auth/2.0\nis_valid:true\n", Poison.encode!(@sample_response))
+      conn = callback(context.payload)
       assert conn.assigns == %{}
       assert conn.private == %{steam_user: @sample_user}
     end
@@ -148,9 +112,7 @@ defmodule Ueberauth.Strategy.SteamTest do
   describe "info retrievers fetch" do
     setup do
       conn = %{conn(:get, "http://example.com/path/callback") | private: %{steam_user: @sample_user}}
-
       conn = Steam.handle_callback! conn
-
       [conn: conn]
     end
 
@@ -160,9 +122,12 @@ defmodule Ueberauth.Strategy.SteamTest do
 
     test "info", %{conn: conn} do
       assert Steam.info(conn) == %Ueberauth.Auth.Info{
-             image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe.jpg",
-             location: "NL", name: "Sample Sample",
-             urls: %{Steam: "http://steamcommunity.com/id/sample/"}}
+        image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/f3/f3dsf34324eawdasdas3rwe.jpg",
+        location: "NL",
+        name: "Sample Sample",
+        nickname: "Sample",
+        urls: %{steam_profile: "http://steamcommunity.com/id/sample/"}
+      }
     end
 
     test "extra", %{conn: conn} do
@@ -176,12 +141,7 @@ defmodule Ueberauth.Strategy.SteamTest do
 
   test "connection is cleaned up" do
     conn = %{conn(:get, "http://example.com/path/callback") | private: %{steam_user: @sample_user}}
-
-    conn =
-      conn
-      |> Steam.handle_callback!
-      |> Steam.handle_cleanup!
-
-    assert conn.private == %{steam_user: nil}
+    conn = conn |> Steam.handle_callback! |> Steam.handle_cleanup!
+    assert %{steam_user: nil} = conn.private
   end
 end


### PR DESCRIPTION
- fixes claimed_id under https scheme not recognised
- fixes some users with private profiles crashing the service
- moves user retrieval after auth ticket verification to avoid unnecessary work
- moves OpenID and Steam API logic to dedicated files
- fixes use of HTTPoison in certain places
- stops converting responses to atoms
- bumps meck so tests run again on Erlang/OTP 21